### PR TITLE
fix: add executable candidate system

### DIFF
--- a/src/knitter/__main__.py
+++ b/src/knitter/__main__.py
@@ -127,13 +127,17 @@ def _build(base_dist_dir: Path = Path('dist'), mode: str = 'production'):
         target_path.parent.mkdir(exist_ok=True, parents=True)
 
         # Preprocess via SASS.
-        try:
-            executable: str = 'sass'
-            if sys.platform.startswith('win32'):
-                executable: str = 'sass.bat'
+        executable_candidates: list[str] = ['sass']
+        if sys.platform.startswith('win32'):
+            executable_candidates.append('sass.bat')
 
-            subprocess.run([executable, src_file, target_path])
-        except FileNotFoundError as e:
+        for executable in executable_candidates:
+            try:
+                subprocess.run([executable, src_file, target_path])
+                break
+            except FileNotFoundError:
+                continue
+        else:
             err_msg: str = ('sass not found. Make sure Sass is '
                             'installed and in your PATH. Build cancelled')
             raise BuildException(err_msg)


### PR DESCRIPTION
### Fix: Improve Sass detection on Windows

Previously, Knitter only attempted to use 'sass.bat' on Windows:

```python
if sys.platform.startswith('win32'):
    executable: str = 'sass.bat'
```

This caused issues because some Windows setups already have `sass` accessible without the `.bat` extension. As a result, Knitter would fail to detect Sass even when it was installed.

This PR updates the implementation to try multiple executables. On Windows, it will:

1. Attempt the default `sass` command.
2. If that fails, attempt `sass.bat`.
3. Fail only if neither is available.

This change improves compatibility across Windows environments without affecting other platforms.