### PR TITLE
feat: add --port argument in serve

### DIFF
--- a/src/knitter/__main__.py
+++ b/src/knitter/__main__.py
@@ -73,6 +73,12 @@ def _create_parser() -> argparse.ArgumentParser:
         description='A static site generator originally built for use in the development of the Dev8 website.')
     parser.add_argument('task', choices=['build', 'serve'])
 
+    parser.add_argument(
+        '--port',
+        type=int,
+        default=2016,
+        help='Port to serve on (default: 2016).')
+
     return parser
 
 
@@ -152,7 +158,7 @@ def _build(base_dist_dir: Path = Path('dist'), mode: str = 'production'):
     shutil.copytree(src_assets_dir, assets_dir, dirs_exist_ok=True)
 
 
-def _serve(base_dist_dir: Path = Path('dist')):
+def _serve(base_dist_dir: Path = Path('dist'), port: int = 2016):
     logger: logging.Logger = logging.getLogger('knitter')
 
     try:
@@ -198,7 +204,6 @@ def _serve(base_dist_dir: Path = Path('dist')):
         server.watch(path, build, delay=delay)
 
     host: str = 'localhost'
-    port: int = 2016
     root: str = 'dist/'
 
     logger.info(f'Starting server at http://{host}:{port}...')
@@ -235,4 +240,4 @@ def main():
             logger.error(f'{str(e)}.')
             sys.exit(127)
     elif args.task == 'serve':
-        _serve()
+        _serve(port=args.port)


### PR DESCRIPTION
This pull request enhances the flexibility of the `serve` command in the static site generator by allowing users to specify a custom port via a command-line argument. The default port remains 2016 for backward compatibility, but users can now override it as needed.

**Command-line interface improvements:**

* Added a `--port` argument to the command-line parser, allowing users to specify the port for the `serve` task (default: 2016).

**Serve functionality updates:**

* Updated the `_serve` function to accept a `port` parameter, enabling it to use the port specified by the user.
* Modified the `main()` function to pass the user-specified port to `_serve` when the `serve` task is selected.

**Code cleanup:**

* Removed the hardcoded `port` variable from the `build` function since the port is now passed explicitly.